### PR TITLE
ARM fixes

### DIFF
--- a/parrot_cfg_cern
+++ b/parrot_cfg_cern
@@ -33,16 +33,14 @@ fi
 # Bug not yet reported upstream.
 temp_dir=`grep -i "^GLIDEIN_PARROT_TMP " $glidein_config | awk '{print $2}'`
 alien_cache=`grep -i "^GLIDEIN_PARROT_ALIEN " $glidein_config | awk '{print $2}'`
-grid_repo=`mktemp -d --tmpdir=$temp_dir`
 
-#PARROT_CVMFS_REPO="cms.cern.ch:alien_cachedir=${alien_cache},timeout=3600,timeout_direct=3600,pubkey=${pubkey},url=${CVMFS_STRATUM1},proxies=${CVMFS_PROXIES} grid.cern.ch:timeout=3600,timeout_direct=3600,pubkey=${pubkey},url=http://cvmfs-stratum-one.cern.ch/opt/grid,proxies=${CVMFS_PROXIES},cachedir=${grid_repo},alien_cachedir=${alien_cache}"
 PARROT_CVMFS_REPO="cms.cern.ch:timeout=3600,timeout_direct=3600,pubkey=${pubkey},url=${CVMFS_STRATUM1},proxies=${CVMFS_PROXIES} grid.cern.ch:timeout=3600,timeout_direct=3600,pubkey=${pubkey},url=http://cvmfs-stratum-one.cern.ch/opt/grid,proxies=${CVMFS_PROXIES}"
 
 PARROT_CVMFS_CONFIG="cache_directory=${alien_cache},alien_cache"
 #GLIDEIN_PARROT_OPTIONS=" --debug=notice --debug=cache --debug=cvmfs "
 
 # If true and parrot can't access CVMFS_TEST_PATH, abort glidein startup.
-GlideinRequiresParrotCVMFS=true
+GlideinRequiresParrotCVMFS=false
 
 # If true and test of Frontier squid fails, abort glidein startup.
 GlideinRequiresCMSFrontier=true

--- a/parrot_cms_setup
+++ b/parrot_cms_setup
@@ -241,7 +241,7 @@ echo "GLIDEIN_PARROT_OPTIONS=\" \${GLIDEIN_PARROT_OPTIONS/SITECONF_PATH_MACRO/${
 site_config_xml="$OSG_APP/cmssoft/cms/SITECONF/local/JobConfig/site-local-config.xml"
 if ! [ -e "$site_config_xml" ]; then
     # At non-CMS sites, we may encounter an available CVMFS mount that is not configured.
-    if [ "X$VO_CMS_SW_DIR" == "" ]; then
+    if [ -z "$VO_CMS_SW_DIR" ]; then
         VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
     fi
     echo "Forcing use of parrot; missing site-local-config.xml"
@@ -273,7 +273,7 @@ fi
 storage_xml="$OSG_APP/cmssoft/cms/SITECONF/local/PhEDEx/storage.xml"
 if ! [ -e "$storage_xml" ]; then
     # At non-CMS sites, we may encounter an available CVMFS mount that is not configured.
-    if [ "X$VO_CMS_SW_DIR" == "" ]; then
+    if [ -z "$VO_CMS_SW_DIR" ]; then
         VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
     fi
     site_config_xml="$VO_CMS_SW_DIR/SITECONF/local/PhEDEx/storage.xml"

--- a/parrot_cms_setup
+++ b/parrot_cms_setup
@@ -276,7 +276,7 @@ if ! [ -e "$storage_xml" ]; then
     if [ -z "$VO_CMS_SW_DIR" ]; then
         VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
     fi
-    site_config_xml="$VO_CMS_SW_DIR/SITECONF/local/PhEDEx/storage.xml"
+    storage_xml="$VO_CMS_SW_DIR/SITECONF/local/PhEDEx/storage.xml"
 fi
 if [ -e "$storage_xml" ]; then
     # Extract site name from: root://cmsxrootd.fnal.gov//store/$1?source=HERE

--- a/parrot_cms_setup
+++ b/parrot_cms_setup
@@ -225,7 +225,13 @@ add_condor_vars_line VO_CMS_SW_DIR "S" "-" "+" "N" "N" "+"
 
 GLIDEIN_PARROT=`grep -i "^GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
 
-echo "GLIDEIN_PARROT_OPTIONS=\"\${GLIDEIN_PARROT_OPTIONS/SITECONF_PATH_MACRO/${siteconf_dir}} -M $CVMFS_VO_CMS_SW_DIR/SITECONF=$siteconf_dir\"" \
+PARROT_DEBUG=`grep -i "^PARROT_DEBUG " $glidein_config | awk '{print $2}'`
+
+if [ "X$PARROT_DEBUG" = "" ]; then
+  GLIDEIN_PARROT_OPTIONS="$GLIDEIN_PARROT_OPTIONS -d cvmfs"
+fi
+
+echo "GLIDEIN_PARROT_OPTIONS=\" \${GLIDEIN_PARROT_OPTIONS/SITECONF_PATH_MACRO/${siteconf_dir}} -M $CVMFS_VO_CMS_SW_DIR/SITECONF=$siteconf_dir\"" \
   >> $GLIDEIN_PARROT/setup.sh \
   || die VO_Config "failed to append to parrot/setup.sh"
 

--- a/parrot_setup
+++ b/parrot_setup
@@ -256,6 +256,8 @@ if [ ! -e "$GLIDEIN_PARROT/parrot_run" ]; then
     die Packaging "parrot_run binary is not unpacked into \"$GLIDEIN_PARROT\""
 fi
 
+$GLIDEIN_PARROT/parrot_run -v
+
 if "$GLIDEIN_PARROT/parrot_run" -d cvmfs -t "$GLIDEIN_PARROT_TMP" test -e $CVMFS_TEST_PATH; then
 
     # publish in the machine ad that this glidein supports parrot CVMFS

--- a/parrot_setup
+++ b/parrot_setup
@@ -25,6 +25,25 @@ condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}
 # find error reporting helper script
 error_gen=`grep '^ERROR_GEN_PATH ' $glidein_config | awk '{print $2}'`
 
+# this case is for <file> in the factory config
+GLIDEIN_PARROT=`grep -i "^GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
+
+# this case is for <file> in the top-level scope of the frontend config
+tmp_glidein_parrot=`grep -i "^GLIDECLIENT_GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
+if [ -n "$tmp_glidein_parrot" ]; then
+    GLIDEIN_PARROT=$tmp_glidein_parrot
+fi
+
+# this case is for <file> in the group scope of the frontend config
+tmp_glidein_parrot=`grep -i "^GLIDECLIENT_GROUP_GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
+if [ -n "$tmp_glidein_parrot" ]; then
+    GLIDEIN_PARROT=$tmp_glidein_parrot
+fi
+
+if [ -z "$GLIDEIN_PARROT" ]; then
+    die VO_Config "No GLIDECLIENT_GLIDEIN_PARROT or GLIDECLIENT_GROUP_GLIDEIN_PARROT found in glidein config.  This could indicate that parrot.tgz was not included in the glidein files or absdir_outattr for this tarball was not set to GLIDEIN_PARROT."
+fi
+
 # configure parrot temp directory
 
 # this case is for <temp dir> in the factory config
@@ -101,25 +120,6 @@ source "$parrot_cfg"
 add_config_line PARROT_RUN_WORKS FALSE
 
 # find the unpacked parrot.tgz tarball location
-
-# this case is for <file> in the factory config
-GLIDEIN_PARROT=`grep -i "^GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
-
-# this case is for <file> in the top-level scope of the frontend config
-tmp_glidein_parrot=`grep -i "^GLIDECLIENT_GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
-if [ -n "$tmp_glidein_parrot" ]; then
-    GLIDEIN_PARROT=$tmp_glidein_parrot
-fi
-
-# this case is for <file> in the group scope of the frontend config
-tmp_glidein_parrot=`grep -i "^GLIDECLIENT_GROUP_GLIDEIN_PARROT " $glidein_config | awk '{print $2}'`
-if [ -n "$tmp_glidein_parrot" ]; then
-    GLIDEIN_PARROT=$tmp_glidein_parrot
-fi
-
-if [ -z "$GLIDEIN_PARROT" ]; then
-    die VO_Config "No GLIDECLIENT_GLIDEIN_PARROT or GLIDECLIENT_GROUP_GLIDEIN_PARROT found in glidein config.  This could indicate that parrot.tgz was not included in the glidein files or absdir_outattr for this tarball was not set to GLIDEIN_PARROT."
-fi
 
 # untar location GLIDECLIENT_GLIDEIN_PARROT is directory containing untarred files
 # point GLIDEIN_PARROT inside the directory contained within the tar file:

--- a/test/test.sh
+++ b/test/test.sh
@@ -72,7 +72,9 @@ diff ../cms_siteconf/SITECONF/local/PhEDEx/storage.xml tmp/storage.xml || die "s
 
 #sh ../../../cvmfs_job_wrapper test -d /cvmfs/icecube.wisc.edu/ || die "cvmfs_job_wrapper failed to find /cvmfs/icecube.wisc.edu"
 
+sh ../../../cvmfs_job_wrapper sh -c 'source /cvmfs/cms.cern.ch/cmsset_default.sh && scram project CMSSW CMSSW_7_4_3' || die "SCRAM setup failed."
+
 echo "Ok, starting up a shell; press Ctrl+C to exit."
-sh ../../../cvmfs_job_wrapper sh
+sh ../../../cvmfs_job_wrapper sh "$@"
 
 echo "Success"


### PR DESCRIPTION
This does two things:
- Fixes some issues we found when running on the ARM server at Princeton.  Basically, if CVMFS was mounted and parrot failed to function, then we would fail validation (even though we would just use CVMFS anyway).  This is no longer true.
- Update to a pre-release of 4.5.0.  This adds support for having a dynamic loader located on CVMFS (which we do in the CMSSW 7 series).
